### PR TITLE
Initial proto definition

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,3 +54,19 @@ pip_install(
 )
 
 register_toolchains("//:py_3_toolchain")
+
+# Proto rules
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+    strip_prefix = "rules_proto-4.0.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+

--- a/api/BUILD
+++ b/api/BUILD
@@ -1,0 +1,14 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "entities",
+    srcs = ["entities.proto"],
+)
+
+proto_library(
+    name = "service",
+    srcs = ["service.proto"],
+    deps = [
+        ":entities",
+    ],
+)

--- a/api/entities.proto
+++ b/api/entities.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+message Uuid {
+    string value = 1;
+}
+
+message Item {
+    Uuid id = 1;
+    Uuid collection_id = 2;
+    Uuid item_type_id = 3;
+    Uuid client_id = 4;
+    string name = 5;
+    uint32 quantity = 6;
+}

--- a/api/service.proto
+++ b/api/service.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+import "api/entities.proto";
+
+service JbcService {
+    rpc AddItem(AddItemRequest) returns (AddItemResponse);
+    rpc RemoveItem(RemoveItemRequest) returns (RemoveItemResponse);
+
+}
+
+message AddItemRequest {
+    // Name of the item. Must be unique
+    string name = 1;
+    // Amount to add
+    uint32 quantity = 2;
+    // The client's ID
+    Uuid client_id = 3;
+    // The ID of the collection to add this item to
+    Uuid collection_id = 4;
+    // OPTIONAL: The ID of the type of item. Will be created if no name match is found
+    Uuid item_type_id = 5;
+}
+
+message AddItemResponse {
+    // ID of the added item
+    Uuid item_id = 1;
+    // The ID of the type of the added item
+    Uuid item_type_id = 2;
+    // The current amount in the collection
+    uint32 quantity = 3;
+}
+
+message RemoveItemRequest {
+    // The ID of the item to remove
+    Uuid item_id = 1;
+    // Amount to remove
+    uint32 quantity = 2;
+}
+
+message RemoveItemResponse {
+    // The current amount in the collection
+    uint32 quantity = 1;
+}

--- a/db/postgres/v1_postgres.sql
+++ b/db/postgres/v1_postgres.sql
@@ -26,7 +26,6 @@ CREATE TABLE IF NOT EXISTS item (
     item_id uuid DEFAULT uuid_generate_v4(),
     collection_id uuid NOT NULL,
     item_type_id uuid NOT NULL,
-    name VARCHAR NOT NULL,
     PRIMARY KEY (item_id),
     CONSTRAINT fk_collection_id FOREIGN KEY (collection_id) REFERENCES item_collection (collection_id),
     CONSTRAINT fk_item_type_id FOREIGN KEY (item_type_id) REFERENCES item_type (item_type_id)

--- a/db/postgres/v1_postgres.sql
+++ b/db/postgres/v1_postgres.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS item (
     item_id uuid DEFAULT uuid_generate_v4(),
     collection_id uuid NOT NULL,
     item_type_id uuid NOT NULL,
+    quantitiy integer NOT NULL,
     PRIMARY KEY (item_id),
     CONSTRAINT fk_collection_id FOREIGN KEY (collection_id) REFERENCES item_collection (collection_id),
     CONSTRAINT fk_item_type_id FOREIGN KEY (item_type_id) REFERENCES item_type (item_type_id)

--- a/db/postgres/v1_postgres.sql
+++ b/db/postgres/v1_postgres.sql
@@ -8,26 +8,26 @@ CREATE TABLE IF NOT EXISTS client (
     PRIMARY KEY (client_id)
 );
 
-CREATE TABLE IF NOT EXISTS CELLAR (
-    cellar_id uuid DEFAULT uuid_generate_v4(),
+CREATE TABLE IF NOT EXISTS item_collection (
+    collection_id uuid DEFAULT uuid_generate_v4(),
     client_id uuid NOT NULL,
     name VARCHAR NOT NULL,
-    PRIMARY KEY (cellar_id),
-    CONSTRAINT fk_user_id FOREIGN KEY (client_id) REFERENCES client (client_id)
+    PRIMARY KEY (collection_id),
+    CONSTRAINT fk_client_id FOREIGN KEY (client_id) REFERENCES client (client_id)
 );
 
-CREATE TABLE IF NOT EXISTS product (
-    product_id uuid DEFAULT uuid_generate_v4(),
+CREATE TABLE IF NOT EXISTS item_type (
+    item_type_id uuid DEFAULT uuid_generate_v4(),
     name VARCHAR NOT NULL,
-    PRIMARY KEY(product_id) 
+    PRIMARY KEY(item_type_id) 
 );
 
-CREATE TABLE IF NOT EXISTS beer (
-    beer_id uuid DEFAULT uuid_generate_v4(),
-    cellar_id uuid NOT NULL,
-    product_id uuid NOT NULL,
+CREATE TABLE IF NOT EXISTS item (
+    item_id uuid DEFAULT uuid_generate_v4(),
+    collection_id uuid NOT NULL,
+    item_type_id uuid NOT NULL,
     name VARCHAR NOT NULL,
-    PRIMARY KEY (cellar_id),
-    CONSTRAINT fk_cellar_id FOREIGN KEY (cellar_id) REFERENCES cellar (cellar_id),
-    CONSTRAINT fk_product_id FOREIGN KEY (product_id) REFERENCES product (product_id)
+    PRIMARY KEY (item_id),
+    CONSTRAINT fk_collection_id FOREIGN KEY (collection_id) REFERENCES item_collection (collection_id),
+    CONSTRAINT fk_item_type_id FOREIGN KEY (item_type_id) REFERENCES item_type (item_type_id)
 );


### PR DESCRIPTION
This creates some simple APIs for the service via proto definitions. The models are split out from the service definition so that they can (theoretically) be use independently. 

This also cleans up the DB definition to be a bit more generic, and adds the proto toolchains to the bazel workspace.